### PR TITLE
Clean up sprites

### DIFF
--- a/compositors/SVGCompositor.js
+++ b/compositors/SVGCompositor.js
@@ -24,8 +24,14 @@ class SVGCompositor {
         spriteSVG = spriteSVG.substring(headerIndexEnd + 2);
       }
       
-      spriteSVG = spriteSVG.replace('<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->', '');
-      spriteSVG = spriteSVG.replace('<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">', '');
+      // Strip comments, if any.
+			spriteSVG = spriteSVG.replace(new RegExp('(<!--([^>]*)-->)', 'g'), '');
+			
+			// Strip Doctype, if any.
+			spriteSVG = spriteSVG.replace(new RegExp('(<!DOCTYPE([^>]*)">)', 'g'), '');
+			
+			//Strip Svg tag.
+			spriteSVG = spriteSVG.replace(new RegExp('(<svg([^>]*)">)|(</svg>)', 'g'), '');
 
       // Rename sprite ids to avoid clashing.
       spriteSVG = postsvg().use(renameId({pattern: 'sprite' + (++spriteId) + '_[id]'})).process(spriteSVG);

--- a/compositors/SVGCompositor.js
+++ b/compositors/SVGCompositor.js
@@ -23,6 +23,9 @@ class SVGCompositor {
         var headerIndexEnd = spriteSVG.indexOf('?>');
         spriteSVG = spriteSVG.substring(headerIndexEnd + 2);
       }
+      
+			spriteSVG = spriteSVG.replace('<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->', '');
+			spriteSVG = spriteSVG.replace('<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">', '');
 
       // Rename sprite ids to avoid clashing.
       spriteSVG = postsvg().use(renameId({pattern: 'sprite' + (++spriteId) + '_[id]'})).process(spriteSVG);

--- a/compositors/SVGCompositor.js
+++ b/compositors/SVGCompositor.js
@@ -24,8 +24,8 @@ class SVGCompositor {
         spriteSVG = spriteSVG.substring(headerIndexEnd + 2);
       }
       
-			spriteSVG = spriteSVG.replace('<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->', '');
-			spriteSVG = spriteSVG.replace('<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">', '');
+      spriteSVG = spriteSVG.replace('<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->', '');
+      spriteSVG = spriteSVG.replace('<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">', '');
 
       // Rename sprite ids to avoid clashing.
       spriteSVG = postsvg().use(renameId({pattern: 'sprite' + (++spriteId) + '_[id]'})).process(spriteSVG);

--- a/compositors/SVGCompositor.js
+++ b/compositors/SVGCompositor.js
@@ -25,13 +25,13 @@ class SVGCompositor {
       }
       
       // Strip comments, if any.
-			spriteSVG = spriteSVG.replace(new RegExp('(<!--([^>]*)-->)', 'g'), '');
+      spriteSVG = spriteSVG.replace(new RegExp('(<!--([^>]*)-->)', 'g'), '');
 			
-			// Strip Doctype, if any.
-			spriteSVG = spriteSVG.replace(new RegExp('(<!DOCTYPE([^>]*)">)', 'g'), '');
+      // Strip Doctype, if any.
+      spriteSVG = spriteSVG.replace(new RegExp('(<!DOCTYPE([^>]*)">)', 'g'), '');
 			
-			//Strip Svg tag.
-			spriteSVG = spriteSVG.replace(new RegExp('(<svg([^>]*)">)|(</svg>)', 'g'), '');
+      //Strip Svg tag.
+      spriteSVG = spriteSVG.replace(new RegExp('(<svg([^>]*)">)|(</svg>)', 'g'), '');
 
       // Rename sprite ids to avoid clashing.
       spriteSVG = postsvg().use(renameId({pattern: 'sprite' + (++spriteId) + '_[id]'})).process(spriteSVG);


### PR DESCRIPTION
This removes excess comments, multiple doctype declarations and <svg> tags from sprites before creating the spritesheet.

I know this is an old repo but it works perfect with this update.

Hopefully I'm doing it right, this is my first pull request.